### PR TITLE
update select-mock-targets config file

### DIFF
--- a/mini/select-mock-targets.yaml
+++ b/mini/select-mock-targets.yaml
@@ -1,63 +1,63 @@
 # mock target configuration file
-dust_dir: /project/projectdirs/desi/software/edison/dust/v0_1/maps
+dust_dir: '{DUST_DIR}/maps'
 sources:
     BGS: {
         target_name: BGS,
-        mockfile: /project/projectdirs/desi/mocks/bgs/MXXL/desi_footprint/v0.0.4/BGS.hdf5,
+        mockfile: '{DESI_ROOT}/mocks/bgs/MXXL/desi_footprint/v0.0.4/BGS.hdf5',
         format: durham_mxxl_hdf5,
         magcut: 20.2,
     }
     ELG: {
         target_name: ELG,
-        mockfile: /project/projectdirs/desi/mocks/GaussianRandomField/v0.0.7_2LPT/ELG.fits,
+        mockfile: '{DESI_ROOT}/mocks/GaussianRandomField/v0.0.7_2LPT/ELG.fits',
         format: gaussianfield,
         density: 2155,
     }
     LRG: {
         target_name: LRG,
-        mockfile: /project/projectdirs/desi/mocks/GaussianRandomField/v0.0.7_2LPT/LRG.fits,
+        mockfile: '{DESI_ROOT}/mocks/GaussianRandomField/v0.0.7_2LPT/LRG.fits',
         format: gaussianfield,
         density: 480,
     }
     QSO: {
         target_name: QSO,
-        mockfile: /project/projectdirs/desi/mocks/GaussianRandomField/v0.0.7_2LPT/QSO.fits,
+        mockfile: '{DESI_ROOT}/mocks/GaussianRandomField/v0.0.7_2LPT/QSO.fits',
         format: gaussianfield,
         density: 120,
     }
     LYA: {
         target_name: LYA,
-        mockfile: /project/projectdirs/desi/mocks/lya_forest/v2.0.2/master.fits,
+        mockfile: '{DESI_ROOT}/mocks/lya_forest/v2.0.2/master.fits',
         format: CoLoRe,
         nside_lya: 16,
         density: 50,
     }
     MWS_MAIN: {
         target_name: MWS_MAIN,
-        mockfile: /project/projectdirs/desi/mocks/mws/galaxia/alpha/v0.0.5/healpix,
+        mockfile: '{DESI_ROOT}/mocks/mws/galaxia/alpha/v0.0.5/healpix',
         nside_galaxia: 8,
         format: galaxia,
     }
     MWS_NEARBY: {
         target_name: MWS_NEARBY,
-        mockfile: /project/projectdirs/desi/mocks/mws/100pc/v0.0.3/mock_100pc.fits,
+        mockfile: '{DESI_ROOT}/mocks/mws/100pc/v0.0.3/mock_100pc.fits',
         format: mws_100pc,
     }
     WD: {
         target_name: WD,
-        mockfile: /project/projectdirs/desi/mocks/mws/wd/v0.0.2/mock_wd.fits,
+        mockfile: '{DESI_ROOT}/mocks/mws/wd/v0.0.2/mock_wd.fits',
         format: mws_wd,
     }
     FAINTSTAR: {
         target_name: FAINTSTAR,
-        mockfile: /project/projectdirs/desi/mocks/mws/galaxia/alpha/0.0.5_superfaint/healpix,
+        mockfile: '{DESI_ROOT}/mocks/mws/galaxia/alpha/0.0.5_superfaint/healpix',
         nside_galaxia: 8,
         format: galaxia,
         magcut: 23.5,
     }
     SKY: {
         target_name: SKY,
-        mockfile: /project/projectdirs/desi/mocks/uniformsky/0.1/uniformsky-2048-0.1.fits,
+        mockfile: '{DESI_ROOT}/mocks/uniformsky/0.1/uniformsky-2048-0.1.fits',
         format: uniformsky,
         density: 1400,
     }


### PR DESCRIPTION
Update to `select-mock-targets.yaml` file based on https://github.com/desihub/desitarget/pull/325.

May also require https://github.com/desihub/desimodules/issues/22 to be resolved before merging to ensure `$DUST_DIR` is properly set.