### PR TITLE
updating minitest notebook for 20.4

### DIFF
--- a/mini/desisurvey-config.yaml
+++ b/mini/desisurvey-config.yaml
@@ -137,14 +137,12 @@ fiber_assignment_cadence: daily
 # Similarly, a delay of 0 indicates that fibers are assigned on
 # the first day / month after the covering tiles are completed.
 fiber_assignment_order:
-    P1: P0 delay 1
-    P2: P0+P1 delay 1
-    P3: P0+P1 delay 1
-###    P6: P5 delay 1
-###    P7: P5+P6 delay 1
+    P2: P1 delay 1
+    P3: P1+P2 delay 1
+    P4: P1+P2 delay 1
 
 # Nominal tile radius for determining whether two tiles overlap.
-tile_radius: 1.62 deg
+tile_radius: 1.63 deg
 
 #-------------------------------------------------------------------
 # Parameters to locate files needed by desisurvey.

--- a/mini/desisurvey-config.yaml
+++ b/mini/desisurvey-config.yaml
@@ -74,6 +74,9 @@ programs:
 # Never observe below this limit.
 min_altitude: 30 deg
 
+# Never observer at larger HA than 5 hr.
+max_hour_angle: 75 deg
+
 # Time required to setup for a new field, including slew, fiber positioning, etc.
 new_field_setup : 120 s
 


### PR DESCRIPTION
This PR updates the minitest notebook for the 20.4 software release reference run.

A new config option `max_hour_angle` was needed in the `desisurvey-config.yaml` file, and various tweaks were needed to the notebook itself to adapt to the new tiling pattern.

Outputs are currently in `/global/cscratch1/sd/sjbailey/minitest-20.4` and will be moved to `/global/cfs/cdirs/desi/datachallenge/reference_runs/20.4` once merged and desitest 20.4 tagged.