### PR TITLE
update specex

### DIFF
--- a/py/desitest/nersc.py
+++ b/py/desitest/nersc.py
@@ -75,8 +75,7 @@ def update(basedir=None, logdir='.', repos=None):
 
             #- specex: compiled code
             if repo == 'specex':
-                ### commands = ['git pull', 'make install']
-                commands = ['git pull', 'python setup.py clean install --prefix ./code']
+                commands = ['git pull', 'python setup.py build_ext --inplace']
 
             #- desimodel: also update svn data
             if repo == 'desimodel':

--- a/py/desitest/nersc.py
+++ b/py/desitest/nersc.py
@@ -42,6 +42,7 @@ def update(basedir=None, logdir='.', repos=None):
             'redrock-templates',
             'simqso',
             'fiberassign',
+            'specex',
             'prospect',
             'desimeter',
         ]
@@ -71,6 +72,11 @@ def update(basedir=None, logdir='.', repos=None):
             if repo == 'fiberassign':
                 ### commands = ['git pull', 'make install']
                 commands = ['git pull', 'python setup.py build_ext --inplace', 'python setup.py test']
+
+            #- specex: compiled code
+            if repo == 'specex':
+                ### commands = ['git pull', 'make install']
+                commands = ['git pull', 'python setup.py clean install --prefix ./code']
 
             #- desimodel: also update svn data
             if repo == 'desimodel':


### PR DESCRIPTION
Adds code to automatically update master branch of specex using
`python setup.py clean install --prefix ./code`
consistent with current tagged and master versions of specex being located in the code subdirectory of the specex package. 

Please review and merge. 