### PR TITLE
Add gpu_specter to list of packages to update

### DIFF
--- a/py/desitest/nersc.py
+++ b/py/desitest/nersc.py
@@ -37,6 +37,7 @@ def update(basedir=None, logdir='.', repos=None):
         repos = [
             'desiutil',
             'specter',
+            'gpu_specter',
             'desimodel',
             'desitarget',
             'desispec',


### PR DESCRIPTION
Add gpu_specter to the list of packages to update, in order to have the latest version on cori and perlmutter.