### PR TITLE
Always chmod as last update command

### DIFF
--- a/py/desitest/nersc.py
+++ b/py/desitest/nersc.py
@@ -65,7 +65,9 @@ def update(basedir=None, logdir='.', repos=None):
             'fastspecfit',
         ]
 
-    pullcmd='git pull && chmod -R a+rX .'
+    pullcmd='git pull'
+    chmodcmd='chmod -R a+rX .'
+
     something_failed = False
     for repo in repos:
         t0 = time.time()
@@ -139,6 +141,9 @@ def update(basedir=None, logdir='.', repos=None):
                     pullcmd,
                     "python -m compileall -f simqso",
                     ]
+
+            # always set permissions as the last command
+            commands.append(chmodcmd)
 
             assert pullcmd in commands
             for cmd in commands:


### PR DESCRIPTION
Fixes #45 by running chmod -R a+rX . after every nightly update of the main branch to ensure world readability. The first attempt was #48, but that was not a complete solution because steps after `git pull` could result in a change in the permissions. 